### PR TITLE
Fix ScrapyDeprecationWarning log messages

### DIFF
--- a/example_project/example_project/spiders/example.py
+++ b/example_project/example_project/spiders/example.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
  
-from scrapy.spider import BaseSpider
+from scrapy import Spider
 
-class NitidumSpider(BaseSpider):
+class NitidumSpider(Spider):
 
     name = 'example'
     allowed_domains = ['localhost']

--- a/scrapy_sentry/extensions.py
+++ b/scrapy_sentry/extensions.py
@@ -6,8 +6,9 @@ Use SENTRY_DSN setting to enable sending information
 from __future__ import absolute_import, unicode_literals
 
 import os
+import logging
 
-from scrapy import signals, log
+from scrapy import signals
 from scrapy.mail import MailSender  # noqa
 from scrapy.exceptions import NotConfigured
 
@@ -96,6 +97,6 @@ class Errors(object):
         ident = self.client.get_ident(msg)
 
         l = spider.log if spider else log.msg
-        l("Sentry Exception ID '%s'" % ident, level=log.INFO)
+        l("Sentry Exception ID '%s'" % ident, level=logging.INFO)
 
         return ident

--- a/scrapy_sentry/middlewares.py
+++ b/scrapy_sentry/middlewares.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 
 import os
 import sys
+import logging
 
-from scrapy import log
 from scrapy.conf import settings  # noqa
 from scrapy.exceptions import NotConfigured
 
@@ -31,7 +31,7 @@ class SentryMiddleware(object):
         ident = self.client.get_ident(msg)
 
         l = spider.log if spider else log.msg
-        l("Sentry Exception ID '%s'" % ident, level=log.INFO)
+        l("Sentry Exception ID '%s'" % ident, level=logging.INFO)
 
         return None
 


### PR DESCRIPTION
Fix ScrapyDeprecationWarning log messages in extensions, middlewares
and spider example

Close #7 