### PR TITLE
Importing settings from scrapy.conf is deprecated

### DIFF
--- a/scrapy_sentry/middlewares.py
+++ b/scrapy_sentry/middlewares.py
@@ -4,11 +4,13 @@ import os
 import sys
 
 from scrapy import log
-from scrapy.conf import settings  # noqa
+# from scrapy.conf import settings  # noqa
+from scrapy.utils.project import get_project_settings
 from scrapy.exceptions import NotConfigured
 
 from .utils import get_client
 
+settings = get_project_settings()
 
 class SentryMiddleware(object):
     def __init__(self, dsn=None, client=None):

--- a/scrapy_sentry/utils.py
+++ b/scrapy_sentry/utils.py
@@ -4,7 +4,8 @@ import logging
 
 from twisted.python import log
 
-from scrapy.conf import settings
+# from scrapy.conf import settings
+from scrapy.utils.project import get_project_settings
 from scrapy.http import Request, Headers  # noqa
 from scrapy.utils.reqser import request_to_dict, request_from_dict  # noqa
 from scrapy.responsetypes import responsetypes
@@ -15,6 +16,7 @@ from raven.handlers.logging import SentryHandler
 
 SENTRY_DSN = os.environ.get("SENTRY_DSN", None)
 
+settings = get_project_settings()
 
 def get_client(dsn=None):
     """gets a scrapy client"""


### PR DESCRIPTION
To solve this issue
https://github.com/llonchj/scrapy-sentry/issues/2

It will be great if it can be merged soon since it won't work without it