### PR TITLE
Remove deprecated scrapy utils

### DIFF
--- a/scrapy_sentry/utils.py
+++ b/scrapy_sentry/utils.py
@@ -10,7 +10,6 @@ from twisted.python import log
 # from scrapy.conf import settings
 from scrapy.utils.project import get_project_settings
 from scrapy.http import Request, Headers  # noqa
-from scrapy.utils.reqser import request_to_dict, request_from_dict  # noqa
 from scrapy.responsetypes import responsetypes
 
 from raven import Client
@@ -63,7 +62,7 @@ def response_to_dict(response, spider, include_request=True, **kwargs):
         'body': response.body,
     }
     if include_request:
-        d['request'] = request_to_dict(response.request, spider)
+        d['request'] = response.request.to_dict()
     return d
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url='https://github.com/llonchj/scrapy-sentry',
     packages=find_packages(),
     license='BSD',
-    install_requires=['Scrapy>=1.4.0', 'raven>=6.3.0', 'six>=1.11.0'],
+    install_requires=['Scrapy>=2.6.0', 'raven>=6.3.0', 'six>=1.11.0'],
     setup_requires=['setuptools-git-version'],
     tests_require=[
         'pytest-flakes',


### PR DESCRIPTION
As of the latest Scrapy 2.10.0 release this library is running into errors because `scrapy.utils.reqser` has been fully removed from Scrapy after being deprecated in 2.6.0. See [deprecations/removals in 2.10.0](https://docs.scrapy.org/en/latest/news.html#deprecation-removals)

Because this library has been stable for a while, I dropped support for Scrapy <2.6.0 since it seems safe to rely on previous versions of the library for compatibility with older versions of Scrapy and not try to maintain full backwards-compatibilty. If you'd rather add that back in I'm happy to update this.

Thanks for the review, happy to make any changes!